### PR TITLE
[trial] CI: Switch test coverage to Coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
         include:
           - emacs_version: snapshot
             ignore_error: true
+    env:
+      EMACS_VERSION: ${{ matrix.emacs_version }}
     steps:
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
@@ -55,20 +57,8 @@ jobs:
         run: |
           make test
 
-      - name: Coveralls
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
-        uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.github_token }}
-          flag-name: emacs-${{ matrix.emacs_version }}
-          parallel: true
-
-  finish:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true
+          env_vars: EMACS_VERSION

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -20,7 +20,6 @@
   (with-no-warnings
     (undercover "*.el"
                 (:exclude "kubernetes-evil.el")
-                (:merge-report nil)
                 (:report-format 'lcov)
                 (:send-report nil))))
 


### PR DESCRIPTION
Coveralls reports don't seem to display the source code when using the
official Github Action, with no obvious documented solution.

Meanwhile, Codecov seems to work just fine, with the added benefits
of: more streamlined CI configuration; and more elegant and insightful
reporting.

We propose switching to Codecov here. 